### PR TITLE
remove hard coded topics from consumers/server.py

### DIFF
--- a/project/starter/consumers/server.py
+++ b/project/starter/consumers/server.py
@@ -18,7 +18,7 @@ import topic_check
 
 
 logger = logging.getLogger(__name__)
-
+WEB_SERVER_PORT = 8889
 
 class MainHandler(tornado.web.RequestHandler):
     """Defines a web request handler class"""
@@ -46,7 +46,8 @@ def run_server():
             "Ensure that the KSQL Command has run successfully before running the web server!"
         )
         exit(1)
-    if topic_check.topic_exists("org.chicago.cta.stations.table.v1") is False:
+
+    if topic_check.topic_pattern_match("stations.table") is False:
         logger.fatal(
             "Ensure that Faust Streaming is running successfully before running the web server!"
         )
@@ -58,23 +59,23 @@ def run_server():
     application = tornado.web.Application(
         [(r"/", MainHandler, {"weather": weather_model, "lines": lines})]
     )
-    application.listen(8888)
+    application.listen(WEB_SERVER_PORT)
 
     # Build kafka consumers
     consumers = [
         KafkaConsumer(
-            "org.chicago.cta.weather.v1",
+            "(\w*|\.)*weather(.(\w*|\.))*",
             weather_model.process_message,
             offset_earliest=True,
         ),
         KafkaConsumer(
-            "org.chicago.cta.stations.table.v1",
+            "(\w*|\.)*stations.table(.(\w*|\.))",
             lines.process_message,
             offset_earliest=True,
             is_avro=False,
         ),
         KafkaConsumer(
-            "^org.chicago.cta.station.arrivals.",
+            "(\w*|\.)*station.arrivals.(.(\w*|\.))*",
             lines.process_message,
             offset_earliest=True,
         ),
@@ -88,7 +89,7 @@ def run_server():
 
     try:
         logger.info(
-            "Open a web browser to http://localhost:8888 to see the Transit Status Page"
+            f"Open a web browser to http://localhost:{WEB_SERVER_PORT} to see the Transit Status Page"
         )
         for consumer in consumers:
             tornado.ioloop.IOLoop.current().spawn_callback(consumer.consume)


### PR DESCRIPTION
Since the students are asked to come up with names for the topics, it's not good to check for and consume hard coded topic names.

Also. When working in the Udacity workspace, Jupyter runs on `localhost:8888` so trying to have Tornado listen on that port results in `OSError: [Errno 98] Address already in use`