### PR TITLE
add `topic_pattern_match()`

### DIFF
--- a/project/starter/consumers/topic_check.py
+++ b/project/starter/consumers/topic_check.py
@@ -6,3 +6,18 @@ def topic_exists(topic):
     client = AdminClient({"bootstrap.servers": "PLAINTEXT://localhost:9092"})
     topic_metadata = client.list_topics(timeout=5)
     return topic in set(t.topic for t in iter(topic_metadata.topics.values()))
+
+def contains_substring(to_test, substr):
+    _before, match, _after = to_test.partition(substr)
+    return len(match) > 0
+
+def topic_pattern_match(pattern):
+    """
+        Takes a string `pattern`
+        Returns `True` if one or more topic names contains substring `pattern`.
+        Returns `False` if not.
+    """
+    topic_metadata = client.list_topics()
+    topics = topic_metadata.topics
+    filtered_topics = {key: value for key, value in topics.items() if contains_substring(key, pattern)}
+    return len(filtered_topics) > 0


### PR DESCRIPTION
In order to remove the hardcoded topic names in `consumers/server.py` we need to check the presence of topics another way